### PR TITLE
add missing browserify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "backbone": "^1.1.2",
     "bower": "^1.4.1",
+    "browserify": "^10.2.1",
     "duplexify": "^3.4.0",
     "gulp": "^3.8.11",
     "irc": "Jake0oo0/node-irc",


### PR DESCRIPTION
wanted to try this project and this was missing.

---

I also get an error from `gulp build`:

```
[Error: Error: ENOENT, no such file or directory 'vendor/components/backbone.marionette/lib/backbone.marionette.js'
In module tree:
    main
      app

    at Error (native)
]
```

how can I fix that?
